### PR TITLE
Add encoding explicitly to prevent `charmap` decode issue

### DIFF
--- a/countrycode/countrycode.py
+++ b/countrycode/countrycode.py
@@ -14,7 +14,7 @@ except ImportError:
 pkg_dir, pkg_filename = os.path.split(__file__)
 data_path = os.path.join(pkg_dir, "data", "codelist.csv")
 
-with open(data_path) as f:
+with open(data_path, encoding='utf-8') as f:
     rows = csv.reader(f)
     codelist = {col[0]: list(col[1:]) for col in zip(*rows)}
 


### PR DESCRIPTION
Good day, @vincentarelbundock. I propose to add explicitly encoding in `countrycode.py` to prevent decode issue. This error particularly happens in Windows machine. The error that I have encountered is following:
![image](https://github.com/user-attachments/assets/b48d889e-2353-43f4-b916-d23aab56a75f)

This issue is that windows cannot decode well using default `cp1252`. 
This error is tightly related to the issue raised: https://github.com/vincentarelbundock/pycountrycode/issues/12

Defining encoding while opening the file helps to prevent the error in Windows machines.